### PR TITLE
development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .RData
 .Rhistory
 
+# direnv config
+.envrc
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,3 +19,4 @@ Jupyter notebooks to illustrate various aspects and use cases for Jupyter notebo
 1. `r-python`: interacting with R from within a Python notebook.
 1. `slides`: examples of creating slideshows from notebooks.
 1. `mypy`: example of using the `nb_mypy` package to check types in notebooks.
+1. `latex`: examples of using LaTeX in notebooks.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,3 +18,4 @@ Jupyter notebooks to illustrate various aspects and use cases for Jupyter notebo
 1. `bash-python`: interacting with the system shell from within a notebook.
 1. `r-python`: interacting with R from within a Python notebook.
 1. `slides`: examples of creating slideshows from notebooks.
+1. `mypy`: example of using the `nb_mypy` package to check types in notebooks.

--- a/examples/latex/README.md
+++ b/examples/latex/README.md
@@ -1,0 +1,12 @@
+# LaTeX
+
+You can include mathematical expressions and formulas in your Jupyter
+notebooks. Although they are not rendered in production quality, they are still
+very  useful for documentation and educational purposes.
+
+
+## What is it?
+
+1. `latex_macros.ipynb`: A Jupyter notebook that defines LaTeX macros that can
+   be used throughout the notebook.
+1. `latex_macros.py`: paired Python script.

--- a/examples/latex/latex_macros.ipynb
+++ b/examples/latex/latex_macros.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "## $\\LaTeX$ macros"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "You can define your own $\\LaTeX$ macros using `\\newcommand` as you would in an ordinary $\\LaTeX$ file.  If you do that near the top of your document, these macros can be used throughout the notebook.  For this to work, you need to evaluate the cell (this one) containing these macro definitions.\n",
+    "$$\n",
+    "  \\newcommand{\\RR}{\\mathbb{R}}\n",
+    "  \\newcommand{\\vect}[1]{\\boldsymbol{#1}}\n",
+    "  \\newcommand{\\argmax}{\\mathop{\\mathrm{arg\\,max}}}\n",
+    "$$\n",
+    "In this cell, `\\RR` is defined to denote the set of real numbers, `\\vect` to typeset a vector in bold, and the mathematical operator `\\argmax` that can be used in blocks as well as inline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Now in a text, we can use $\\RR$ to denote the set of real numbers.  Also $\\argmax_i v_i$ works inline and in a block.\n",
+    "$$\n",
+    "  \\argmax_{i} v_i\n",
+    "$$\n",
+    "A vector $\\vect{v}$ is also properly rendered."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "notebook_metadata_filter": "kernelspec,language_info"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/latex/latex_macros.py
+++ b/examples/latex/latex_macros.py
@@ -1,0 +1,44 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     notebook_metadata_filter: kernelspec,language_info
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.13.5
+# ---
+
+# %% [markdown]
+# ## $\LaTeX$ macros
+
+# %% [markdown]
+# You can define your own $\LaTeX$ macros using `\newcommand` as you would in an ordinary $\LaTeX$ file.  If you do that near the top of your document, these macros can be used throughout the notebook.  For this to work, you need to evaluate the cell (this one) containing these macro definitions.
+# $$
+#   \newcommand{\RR}{\mathbb{R}}
+#   \newcommand{\vect}[1]{\boldsymbol{#1}}
+#   \newcommand{\argmax}{\mathop{\mathrm{arg\,max}}}
+# $$
+# In this cell, `\RR` is defined to denote the set of real numbers, `\vect` to typeset a vector in bold, and the mathematical operator `\argmax` that can be used in blocks as well as inline.
+
+# %% [markdown]
+# Now in a text, we can use $\RR$ to denote the set of real numbers.  Also $\argmax_i v_i$ works inline and in a block.
+# $$
+#   \argmax_{i} v_i
+# $$
+# A vector $\vect{v}$ is also properly rendered.

--- a/examples/mypy/README.md
+++ b/examples/mypy/README.md
@@ -1,0 +1,11 @@
+# mypy
+
+Type hints are quite useful for robust development. This directory contains a
+very small example to illustrate the use of the `nb_mypy` package, which
+enables the use of `mypy` in Jupyter notebooks.
+
+
+## What is it?
+
+1. `type_hints.ipynb`: a Jupyter notebook with type hints and some errors.
+1. `type_hints.py`: paired Python script.

--- a/examples/mypy/type_hints.ipynb
+++ b/examples/mypy/type_hints.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "You can enable Python's type hints checking in Jupyter Lab by installing the `nb_mypy` extension using `pip install nb_mypy`.  Once installed, you load the extension in the session you want typechecking in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Version 1.0.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext nb_mypy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "To activate type checking, turn it on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%nb_mypy On"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "The following function expects a `str` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def say_hello(name: str) -> None:\n",
+    "    print(f'hello {name}!')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "When calling it with a string, e.g., `'gjb'`, everything is well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello gjb!\n"
+     ]
+    }
+   ],
+   "source": [
+    "say_hello('gjb')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "On the other hand, if you can it with, e.g., an `int`, an error message is printed, but note that the code is executed, as you would expect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<cell>1: \u001b[1m\u001b[31merror:\u001b[m Argument 1 to \u001b[m\u001b[1m\"say_hello\"\u001b[m has incompatible type \u001b[m\u001b[1m\"int\"\u001b[m; expected \u001b[m\u001b[1m\"str\"\u001b[m  \u001b[m\u001b[33m[arg-type]\u001b[m\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello 5!\n"
+     ]
+    }
+   ],
+   "source": [
+    "say_hello(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "notebook_metadata_filter": "kernelspec,language_info"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/mypy/type_hints.py
+++ b/examples/mypy/type_hints.py
@@ -1,0 +1,59 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     notebook_metadata_filter: kernelspec,language_info
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.13.5
+# ---
+
+# %% [markdown]
+# You can enable Python's type hints checking in Jupyter Lab by installing the `nb_mypy` extension using `pip install nb_mypy`.  Once installed, you load the extension in the session you want typechecking in.
+
+# %%
+# %load_ext nb_mypy
+
+# %% [markdown]
+# To activate type checking, turn it on.
+
+# %%
+# %nb_mypy On
+
+# %% [markdown]
+# The following function expects a `str` parameter.
+
+# %%
+def say_hello(name: str) -> None:
+    print(f'hello {name}!')
+
+
+# %% [markdown]
+# When calling it with a string, e.g., `'gjb'`, everything is well.
+
+# %%
+say_hello('gjb')
+
+# %% [markdown]
+# On the other hand, if you can it with, e.g., an `int`, an error message is printed, but note that the code is executed, as you would expect.
+
+# %%
+say_hello(5)
+
+# %%


### PR DESCRIPTION
- Add direnv config file to gitignore
- Add example of checking type hints in notebooks
- Add LaTeX macro definition examples

## Summary by Sourcery

Add Jupyter notebook examples for nb_mypy type checking and LaTeX macros, update example listings and documentation, and ignore direnv config file

New Features:
- Add a mypy example demonstrating type hint checking in Jupyter notebooks
- Add a LaTeX example demonstrating custom macro definitions in Jupyter notebooks

Enhancements:
- Update the main examples README to list the new 'mypy' and 'latex' examples

Build:
- Ignore the direnv configuration file in .gitignore

Documentation:
- Add README files for the 'mypy' and 'latex' example directories