### PR TITLE
Add autoreload example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -19,4 +19,5 @@ Jupyter notebooks to illustrate various aspects and use cases for Jupyter notebo
 1. `r-python`: interacting with R from within a Python notebook.
 1. `slides`: examples of creating slideshows from notebooks.
 1. `mypy`: example of using the `nb_mypy` package to check types in notebooks.
+1. `modules`: develop modules while interacting with them in a notebook.
 1. `latex`: examples of using LaTeX in notebooks.

--- a/examples/modules/README.md
+++ b/examples/modules/README.md
@@ -1,0 +1,19 @@
+# Modules
+
+Although Jupyter notebooks are a great help for data exploration and explorative
+programming, they aren't exactly the best option for code reuse.  You really
+shouldn't end up copy/pasting cells between notebooks that contains your function
+and class defintions.  These should be put in modules that can be imported into
+your notebooks.
+
+The `autoreload` extensiion helps you during development of such modules.  It
+automatically reloads modules before executing user code, so that you don't have to
+restart the kernel to see changes made to your modules.
+
+
+## What is it?
+
+1. `messages.py`: a Python module you are "developing".
+1. `autoreload.ipynb`: a Jupyter notebook that uses the `messages` module and
+   describes a scenario where autoreload is useful.
+1. `autoreload.py`: paired Python script.

--- a/examples/modules/autoreload.ipynb
+++ b/examples/modules/autoreload.ipynb
@@ -1,0 +1,295 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "It is good practice to define functions and classes that you intend in modules, rather than directly in a Jupyter notebook.  However, given that the module may change to add features or fix bugs, there would have to be a convenient way to reload it.  This can be accomplished using the `autoreload` extension.\n",
+    "\n",
+    "First, load the extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "Next, activate the extension, modules will be reloaded before code is executed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "Import a module that you are \"developing\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import messages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "This is its current content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[33m'''\u001b[39m\n",
+       "\u001b[33mSimple module to illustrate the Jupyter Lab autoreload extension.\u001b[39m\n",
+       "\u001b[33m'''\u001b[39m\n",
+       "\n",
+       "\u001b[38;5;28;01mdef\u001b[39;00m say_hello(name: str) -> \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+       "    print(f'hello {name}!')\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%pycat messages.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "Of course, you can call the function `say_hello`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello gjb!\n"
+     ]
+    }
+   ],
+   "source": [
+    "messages.say_hello('gjb')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function say_hello in module messages:\n",
+      "\n",
+      "say_hello(name: str) -> None\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(messages.say_hello)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "Add the following documentation to the `say_hello` function:\n",
+    "```\n",
+    "'''Say hello to someone.\n",
+    "\n",
+    "Parameters\n",
+    "----------\n",
+    "name: str\n",
+    "    name of person to say hello to\n",
+    "'''\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Help on function say_hello in module messages:\n",
+      "\n",
+      "say_hello(name: str) -> None\n",
+      "    Say hello to someone.\n",
+      "\n",
+      "    Parameters\n",
+      "    ----------\n",
+      "    name: str\n",
+      "        name of person to say hello to\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "help(messages.say_hello)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13",
+   "metadata": {},
+   "source": [
+    "Add a new function to the module:\n",
+    "```\n",
+    "def say_bye(name: str) -> None:\n",
+    "    '''Say bye to someone.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    name: str\n",
+    "        name of person to say bye to\n",
+    "    '''\n",
+    "    print(f'hello {name}!')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "messages.say_bye('world')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15",
+   "metadata": {},
+   "source": [
+    "Oops, copy/pasting code is a bad idea, fix the message, and run again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bye world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "messages.say_bye('world')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "The `autoreload` extension makes it very easy to mix notebook and module use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "Sometimes it can be useful for performance reasons not to automatically reload modules.  In that case, you can use\n",
+    "```\n",
+    "%autoreload 1\n",
+    "```\n",
+    "and import the modules that should be reloaded using\n",
+    "```\n",
+    "%aimport messages\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "notebook_metadata_filter": "kernelspec,language_info"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/modules/autoreload.py
+++ b/examples/modules/autoreload.py
@@ -1,0 +1,111 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     notebook_metadata_filter: kernelspec,language_info
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+#   language_info:
+#     codemirror_mode:
+#       name: ipython
+#       version: 3
+#     file_extension: .py
+#     mimetype: text/x-python
+#     name: python
+#     nbconvert_exporter: python
+#     pygments_lexer: ipython3
+#     version: 3.13.5
+# ---
+
+# %% [markdown]
+# It is good practice to define functions and classes that you intend in modules, rather than directly in a Jupyter notebook.  However, given that the module may change to add features or fix bugs, there would have to be a convenient way to reload it.  This can be accomplished using the `autoreload` extension.
+#
+# First, load the extension.
+
+# %%
+# %load_ext autoreload
+
+# %% [markdown]
+# Next, activate the extension, modules will be reloaded before code is executed.
+
+# %%
+# %autoreload 2
+
+# %% [markdown]
+# Import a module that you are "developing".
+
+# %%
+import messages
+
+# %% [markdown]
+# This is its current content.
+
+# %%
+# %pycat messages.py
+
+# %% [markdown]
+# Of course, you can call the function `say_hello`.
+
+# %%
+messages.say_hello('gjb')
+
+# %%
+help(messages.say_hello)
+
+# %% [markdown]
+# Add the following documentation to the `say_hello` function:
+# ```
+# '''Say hello to someone.
+#
+# Parameters
+# ----------
+# name: str
+#     name of person to say hello to
+# '''
+# ```
+
+# %%
+help(messages.say_hello)
+
+# %% [markdown]
+# Add a new function to the module:
+# ```
+# def say_bye(name: str) -> None:
+#     '''Say bye to someone.
+#
+#     Parameters
+#     ----------
+#     name: str
+#         name of person to say bye to
+#     '''
+#     print(f'hello {name}!')
+# ```
+
+# %%
+messages.say_bye('world')
+
+# %% [markdown]
+# Oops, copy/pasting code is a bad idea, fix the message, and run again.
+
+# %%
+messages.say_bye('world')
+
+# %% [markdown]
+# The `autoreload` extension makes it very easy to mix notebook and module use.
+
+# %% [markdown]
+# Sometimes it can be useful for performance reasons not to automatically reload modules.  In that case, you can use
+# ```
+# %autoreload 1
+# ```
+# and import the modules that should be reloaded using
+# ```
+# %aimport messages
+# ```

--- a/examples/modules/messages.py
+++ b/examples/modules/messages.py
@@ -1,0 +1,6 @@
+'''
+Simple module to illustrate the Jupyter Lab autoreload extension.
+'''
+
+def say_hello(name: str) -> None:
+    print(f'hello {name}!')


### PR DESCRIPTION
Add example notebook and skeleton module to illustrate the
use of the `autoreload` extension in Jupyter Lab to easily
develop modules and interact with them from a Jupyter notebook.

## Summary by Sourcery

Add a modules example illustrating how to develop Python modules alongside Jupyter notebooks using the autoreload extension

New Features:
- Introduce a modules example demonstrating use of the JupyterLab autoreload extension with a sample notebook, module, and script

Documentation:
- Update the main examples README to include the modules example
- Add a dedicated README in examples/modules explaining the autoreload workflow

Chores:
- Add skeleton messages.py module and paired autoreload.py script under examples/modules